### PR TITLE
Improve pboCliTool output parsing to handle unexpected data

### DIFF
--- a/script-corecycler.ps1
+++ b/script-corecycler.ps1
@@ -5066,8 +5066,19 @@ function Get-CurveOptimizerValues {
         }
 
 
-        # Try to parse the the CO values
-        $coArray = @(($stdOut -Split '\s+') | Where-Object { $_ -Match '\-?\d+' } | ForEach-Object { [Int] $_ } )
+        # Try to parse the CO values
+        $coArray = @()
+
+        $lines = $stdOut -split "`r`n"
+
+        foreach ($line in $lines) {
+            $potentialValues = @($line -split '\s+' | Where-Object { $_ -match '^-?\d+$' } | ForEach-Object { [Int]$_ })
+
+            if ($potentialValues.Count -eq $numPhysCores) {
+                $coArray = $potentialValues
+                break
+            }
+        }
 
         Write-DebugText('The queried and parsed Curve Optimizer values:')
         Write-DebugText($coArray)


### PR DESCRIPTION
This commit improves robustness by:
- Iterating through the output line by line.
- Filtering out only lines that contain exactly the expected number of integer values.
- Selecting the first valid line instead of assuming the last numeric line is correct.